### PR TITLE
Fix sorting

### DIFF
--- a/grid/js/grid.js
+++ b/grid/js/grid.js
@@ -224,16 +224,22 @@ function Grid(){
               var a = m[selectedColumn] || Infinity
                 , b = n[selectedColumn] || Infinity
               ;
+
+              // If the values differ, perform straightforward sorting.
               if(a != b) return a - b;
 
+              // First try to break ties based on the count of unlimited values.
               a = scorecard[m.State].unltd[selectedColumn];
               b = scorecard[n.State].unltd[selectedColumn];
-              if(a != b) return b - a;
+              if(a != b) return a - b;
 
+              // If there is also a tie in terms of the count of unlimired values,
+              // then break ties by the sum across all years.
               a = scorecard[m.State].sum[selectedColumn];
               b = scorecard[n.State].sum[selectedColumn];
               if(a != b) return a - b;
 
+              // As a last resort tie breaker, use alphabetical ordering.
               return d3.ascending(m.State, n.State);
             })
           .map(function(d) { return d[xColumn]; })

--- a/grid/js/schematic.js
+++ b/grid/js/schematic.js
@@ -65,9 +65,13 @@ function corpus(error, contribs, contribs2) {
             .rollup(function(leaves) {
                 var ret = { sum: {}, unltd: {} };
                 requested_columns.forEach(function(c) {
+
+                    // The sum total across all years.
                     ret.sum[c] = d3.sum(leaves, function(d) { return +d[c]; });
+
+                    // The count of unlimited values across all years.
                     ret.unltd[c] = leaves
-                        .filter(function(d) { return d[c]; })
+                        .filter(function(d) { return !d[c]; })
                         .length
                     ;
                   })


### PR DESCRIPTION
This addresses #51 . The bulk of the work was already done, but the logic for computing the `unltd` part of `scorecard` was actually counting the number of _non-unlimited_ values, so the tie breaking at infinity was inverted. This PR inverts the `unltd` computation such that it now counts the number of unlimited values. Also comments were added to the sorting code.
