### PR TITLE
@curran noticed that the lightest color had a yellow tinge to it (#47).

### DIFF
--- a/grid/js/grid.js
+++ b/grid/js/grid.js
@@ -12,7 +12,7 @@ function Grid(){
       // Reds: http://colorbrewer2.org/#type=sequential&scheme=Reds&n=9
     , colors = [
             "#fcbba1" // Prohibited
-          , "#f7fbbf","#c6dbef","#6baed6","#2171b5","#08306b" // Thresholds
+          , "#f7fbff","#c6dbef","#6baed6","#2171b5","#08306b" // Thresholds
           , "#a50f15" // Unlimited
         ]
   ;


### PR DESCRIPTION
This was due to a typo in the hex value.
