### PR TITLE
Fix "Prohibited" values in Contribution Limits

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -336,12 +336,18 @@ function Grid(){
           var value;
           // Handle the case of a threshold scale.
           if(keyColumn){
+
+              // Use the key column values to extract
+              // "Unlimited" and "Prohibited" values.
               value = d[keyColumn] === "Limited"
                 ? +d[selectedColumn]
                 : d[keyColumn] === "No"
-                  ? -Infinity
-                  : Infinity
+                  ? -Infinity // Treated as "Prohibited"
+                  : Infinity // Treated as "Unlimited"
               ;
+
+              // Treat a value of 0 as "Prohibited"
+              value = value === 0 ? -Infinity : value;
           } else {
               value = d[selectedColumn];
               value = (

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -293,7 +293,7 @@ function initContributionLimitsSection(data) {
       var legend = query.donor === "StateP" ? "partyAsDonor" : "default";
       grid
           .colorScale(colorScale[legend])
-          .selectedColumn(querify())
+          .selectedColumn(querify(), true)
           .selectedColumnLabel(labelify())
         () // Call grid()
       ;


### PR DESCRIPTION
This PR is about restoring correct functionality with respect to data values of "Prohibited" in the Contribution Limits section. Addresses two separate issues simultaneously:

 * "Prohibited" color is never appearing #147
 * Value of 0 should be shown as Prohibited #148