### PR TITLE
Make year bold on initial load & grid year select

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -166,7 +166,7 @@ function Grid(){
   function render_year_indicators(){
       // Highlight the tick for the selected year.
       svg.selectAll(".y.axis .tick text")
-          .classed("sortby", function(d) { return +selectedYear === +d; })
+          .classed("sortby", function(d) { return selectedYear === +d; })
       ;
       var yearRect = svg.select(".year-indicator-overlay")
         .selectAll("rect").data([1]);

--- a/js/grid.js
+++ b/js/grid.js
@@ -166,12 +166,7 @@ function Grid(){
   function render_year_indicators(){
       // Highlight the tick for the selected year.
       svg.selectAll(".y.axis .tick text")
-          .each(function() {
-              var self = d3.select(this);
-              self.classed("sortby", selectedYear === self.text());
-              d3.select(this.parentNode).select("line")
-                  .attr()
-          })
+          .classed("sortby", function(d) { return +selectedYear === +d; })
       ;
       var yearRect = svg.select(".year-indicator-overlay")
         .selectAll("rect").data([1]);

--- a/js/grid.js
+++ b/js/grid.js
@@ -133,7 +133,7 @@ function Grid(){
             dispatch.call("highlight", null, []);
           })
         .on("click", function (d){
-            query.year = d.Year;
+            query.year = +d.Year;
             query.state = d.State;
             dispatch.call("query", null, query);
             highlight(d);

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -123,6 +123,8 @@
       ;
 
       // Initialize the sort mode to "Alphabetically" (first button encountered).
+      // This in turn causes the "query" signal to be dispatched,
+      // which kicks off the initial rendering of the grid.
       d3.select(".sorter-slicer").select(".btn").node().click();
 
   } // visualize()

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -121,7 +121,10 @@
           self.on("change").apply(this, []);
         })
       ;
+
+      // Initialize the sort mode to "Alphabetically" (first button encountered).
       d3.select(".sorter-slicer").select(".btn").node().click();
+
   } // visualize()
 
   function ingest(dataset) {


### PR DESCRIPTION
As a followup to #161 , this PR fixes the issue of bold years on initial load.

The reasons why this wasn't working before are:

 * Since the axes are rendered initially inside a transition, the `.text()` values were not being initialized before the call to `render_year_indicators()`, which was depending on the `.text()` values for comparison with the selected year. Luckily, we can use `d` in place of `d3.select(this).text()` to get at the year value reliably. This is what's done in this PR.
 * The text values (and `d` values) for ticks are strings, whereas the selected year is now a number (I believe it used to be a string). So, to make this work we need to parse the `d` value into a number before comparing it with the selected year.