### PR TITLE
Demystify jekyll

### DIFF
--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -89,7 +89,7 @@
       label: Unlimited
       color: "#cb181d"
 - name: Party2Party
-  type: ordinal
+  type: singular
   scale:
     - label: "Forbidden but funds get transferred between the two entities following internal procedures."
       color: "black"

--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -88,3 +88,8 @@
       max: Infinity
       label: Unlimited
       color: "#cb181d"
+- name: Party2Party
+  type: ordinal
+  scale:
+    - label: "Forbidden but funds get transferred between the two entities following internal procedures."
+      color: "black"

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -210,7 +210,7 @@
         });
 
       signal.on("query", function(question) {
-        question.colorScale = colorScale[question.section][question.legend];
+        question.colorScale = colorScale2[question.section][question.legend];
         grid
             .query(question)
           ()
@@ -302,6 +302,28 @@
   ** The colors and labels for the various colorScales are all defined in
   ** Jekyll, so we're using Jekyll template statements to populate the object.
   */
+  var sectionconfig = d3.entries({{ site.data.sections | jsonify }});
+  var colorScale2 = {};
+  sectionconfig.forEach(function(sec) {
+      colorScale2[sec.key] = {};
+      sec.value.legends.forEach(function(leg) {
+          var thresh = leg.type === "threshold"
+            , sc = thresh ? d3.scaleThreshold() : d3.scaleOrdinal()
+            , range = leg.scale.map(function(s) { return s.color; })
+            , domain = leg.scale.map(function(s, i) {
+                  if(thresh) {
+                      s.max = s.max === "Infinity"
+                        ? 1 / 0
+                        : s.max
+                      ;
+                  }
+                  return thresh ? (s.max + 1) : s.label;
+                })
+          ;
+          colorScale2[sec.key][leg.name] = sc.range(range).domain(domain);
+      });
+  });
+
   var colorScale = {};
 {% for section in site.data.sections %}
   colorScale["{{ section[0] }}"] = {};
@@ -317,10 +339,10 @@
 
   // Store the type so we know when to prune the legend.
   colorScale["{{ section[0] }}"]["{{ legend.name }}"].type = "{{legend.type}}";
-
   {% endfor %}
 {% endfor %}
 
+console.log(colorScale, colorScale2)
 
   d3.selectAll(".tab-pane").each(function(d, i) {
       var name = this.id;

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -320,6 +320,8 @@
                   return thresh ? (s.max + 1) : s.label;
                 })
           ;
+          if(thresh) sc.emptyValue = leg.fallback;
+          sc.type = leg.type;
           colorScale2[sec.key][leg.name] = sc.range(range).domain(domain);
       });
   });

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -137,10 +137,9 @@
           .key(function(d) { return d.Year; })
           .key(function(d) { return d.State; })
           .rollup(function(leaves) { return Object.assign.apply(null, leaves); })
-          .map(dataset
-  {% comment %}Check Jekyll config to see if a year is being worked on{%endcomment %}
-  {% if site.filterYear %}
-          .filter(function(d) { return d.Year != +{{ site.filterYear }}; })
+          .map(dataset{% if site.filterYear %}
+  {% comment %}Check Jekyll config to see if a year is excluded.{% endcomment %}
+              .filter(function(d) { return d.Year != +{{ site.filterYear }}; })
   {% endif %})
       ;
   } // ingest()

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -60,6 +60,7 @@ function Tabulus() {
         wiring.on("choice", function(arg) {
             arg.each(function(value, key) {
                 if(value.disable) {
+                  // e.g. Disable the "branch" if recipient is not Candidate
                     container.selectAll("select").each(function() {
                         var self = d3.select(this)
                           , name = self.attr("data-name")
@@ -79,7 +80,7 @@ function Tabulus() {
                         }
                       })
                     ;
-                }
+                } // if(value.disable)
                 // show the question if this is a question
                 if(value.question) {
                     container.select(".field-description")
@@ -94,7 +95,6 @@ function Tabulus() {
             update();
           })
         ;
-
     } // setup()
 
     // Set the state for the various controls, based on the query
@@ -128,6 +128,15 @@ function Tabulus() {
             if(!(curry.donor && curry.recipient)) return;
             if(curry.recipient.value === "Cand" && !curry.branch) return;
 
+            // Handle the Party/Party exception case here:
+            container.select("select[data-name='recipient']")
+              .select("option[value='Party']")
+                .node().disabled = (curry.donor.value == "StateP")
+            ;
+            container.select("select[data-name='donor']")
+              .select("option[value='StateP']")
+                .node().disabled = (curry.recipient.value === "Party")
+            ;
             curry._question = query.question = curry.donor.value
               + "To"
               + curry.recipient.value

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -156,6 +156,8 @@ function Tabulus() {
                 )
             ;
             query.legend = curry.donor.legend || "default";
+            if(curry.donor.value === "StateP" && curry.recipient.value === "Party")
+                query.legend = "Party2Party";
         } else {
             query.question = curry.question.value;
             query.label = curry.question.label;

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -18,11 +18,13 @@ function Tabulus() {
             .each(function() {
                 var self = d3.select(this)
                   , name = [query.section, self.attr("data-name")]
+                  , id = name.join('-')
+                  , uri = name.join('/')
                 ;
                 self
-                    .attr("id", name.join('-') + "-button")
-                    .attr("href", "../modals/" + name.join('/') + ".html")
-                    .attr("data-target", "#" + name.join('-') + "-modal")
+                    .attr("id", id + "-button")
+                    .attr("data-target", "#" + id + "-modal")
+                    .attr("href", "../modals/" + uri + ".html")
                 ;
               })
         ;


### PR DESCRIPTION
@curran, good thing i decided to go through the jekyll docs again.  I discovered the jsonify tag, which is built in, and can be used to convert jekyll config stuff into json.  This pull request does just that for the colorScale stuff. 

Note, that before, we were removing "Infinity" from threshold scales here (and then I guess adding back the value Infinity later). In this one, we're replacing "Infinity" with Infinity, so if you were compensating for that before, you can remove that complexity from your code now.  Well, specifically, I was excluding the last item in the threshold scales (which was usually the word "Infinity").  In a single item scale, however, that left us with a blank domain. This way of creating the colorScales I think is more accurate and true to the jekyll config itself.

The bonus here is that I've created a single item legend for Party->Party.  You can only reach it by url:
http://localhost:4000/#contribution-limits?question=StatePToPartyLimit_Max

In any case, requesting your review on this. :)