### PR TITLE
Color schemify

### DIFF
--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -89,7 +89,7 @@
       label: Unlimited
       color: "#cb181d"
 - name: Party2Party
-  type: ordinal
+  type: singular
   scale:
     - label: "Forbidden but funds get transferred between the two entities following internal procedures."
       color: "black"

--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -88,3 +88,8 @@
       max: Infinity
       label: Unlimited
       color: "#cb181d"
+- name: Party2Party
+  type: ordinal
+  scale:
+    - label: "Forbidden but funds get transferred between the two entities following internal procedures."
+      color: "black"

--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -91,5 +91,5 @@
 - name: Party2Party
   type: singular
   scale:
-    - label: "Forbidden but funds get transferred between the two entities following internal procedures."
+    - label: "Forbidden but funds get transferred between the two entities following internal procedures. And this is a sentence to act as a space filler."
       color: gray

--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -92,4 +92,4 @@
   type: singular
   scale:
     - label: "Forbidden but funds get transferred between the two entities following internal procedures."
-      color: "black"
+      color: gray

--- a/_data/sections/disclosure/legends.yml
+++ b/_data/sections/disclosure/legends.yml
@@ -59,19 +59,19 @@
 - name: default
   type: ordinal
   scale:
-    - label: "Yes"
-      color: "#4393c3"
-    - label: Changed mid-cycle
-      color: "#2166ac"
     - label: "No"
+      color: "#67000d"
+    - label: Changed mid-cycle
       color: "#053061"
     - label: Inoperative mid-cycle
-      color: "#67000d"
-    - label: Missing Data
-      color: gray
+      color: "#4393c3"
+    - label: "Yes"
+      color: "#cb181d"
     - label: "N/A"
-      color: lightgray
+      color: gray
     - label: "disclose donor if >$250"
-      color: "#92c5de"
+      color: lightgray
     - label: "Voluntary"
-      color: green
+      color: darkgray
+    - label: Missing Data
+      color: black

--- a/_data/sections/other-restrictions/legends.yml
+++ b/_data/sections/other-restrictions/legends.yml
@@ -2,17 +2,14 @@
   type: ordinal
   scale:
     - label: "No"
-      color: "#053061"
-    - label: Changed mid-cycle
-      color: "#2166ac"
-    - label: "Yes"
-      color: "#4393c3"
-    - label: Inoperative mid-cycle
       color: "#67000d"
+    - label: Changed mid-cycle
+      color: "#053061"
+    - label: Inoperative mid-cycle
+      color: "#4393c3"
     - label: Inoperative whole cycle
+      color: "#d1e5f0"
+    - label: "Yes"
       color: "#cb181d"
     - label: Missing Data
-      color: gray
-  # - color: "#d95f02"
-  # - color: "#7570b3"
-  # - color: "#e7298a"
+      color: black

--- a/_data/sections/public-financing/legends.yml
+++ b/_data/sections/public-financing/legends.yml
@@ -8,18 +8,18 @@
     - label: Tax Deduction
       color: "#053061"
     - label: None
-      color: gray
+      color: "#67000d"
 - name: default
   type: ordinal
   scale:
     - label: "Yes"
-      color: "#4393c3"
+      color: "#cb181d"
     - label: Changed mid-cycle
-      color: "#2166ac"
-    - label: "No"
       color: "#053061"
+    - label: "No"
+      color: "#67000d"
     - label: Missing Data
-      color: gray
+      color: black
 - name: financing
   type: ordinal
   scale:
@@ -31,9 +31,9 @@
       color: "#2166ac" # medium blue
     - label: Mixed
       color: "#053061" # dark blue
-    - label: None
-      color: lightgray
-    - label: Missing Data
-      color: gray
     - label: Other
+      color: "#d1e5f0"
+    - label: None
       color: "#67000d"
+    - label: Missing Data
+      color: black

--- a/_data/sections/public-financing/legends.yml
+++ b/_data/sections/public-financing/legends.yml
@@ -1,39 +1,39 @@
 - name: taxes
   type: ordinal
   scale:
+    - label: None
+      color: "#67000d"
     - label: Refund
       color: "#4393c3"
     - label: Tax Credit
       color: "#2166ac"
     - label: Tax Deduction
       color: "#053061"
-    - label: None
-      color: "#67000d"
 - name: default
   type: ordinal
   scale:
-    - label: "Yes"
-      color: "#cb181d"
-    - label: Changed mid-cycle
-      color: "#053061"
     - label: "No"
       color: "#67000d"
+    - label: Changed mid-cycle
+      color: "#053061"
+    - label: "Yes"
+      color: "#cb181d"
     - label: Missing Data
       color: black
 - name: financing
   type: ordinal
   scale:
-    - label: Full Public Financing
-      color: "#92c5de" # lighter blue
-    - label: Partial Grant
-      color: "#4393c3" # light blue
-    - label: Matching Funds
-      color: "#2166ac" # medium blue
-    - label: Mixed
-      color: "#053061" # dark blue
-    - label: Other
-      color: "#d1e5f0"
     - label: None
       color: "#67000d"
+    - label: Full Public Financing
+      color: "#053061" # dark blue
+    - label: Partial Grant
+      color: "#2166ac" # medium blue
+    - label: Matching Funds
+      color: "#4393c3" # light blue
+    - label: Mixed
+      color: "#92c5de" # lighter blue
+    - label: Other
+      color: "#d1e5f0"
     - label: Missing Data
       color: black

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -210,7 +210,7 @@
         });
 
       signal.on("query", function(question) {
-        question.colorScale = colorScale2[question.section][question.legend];
+        question.colorScale = colorScale[question.section][question.legend];
         grid
             .query(question)
           ()
@@ -303,9 +303,9 @@
   ** Jekyll, so we're using Jekyll template statements to populate the object.
   */
   var sectionconfig = d3.entries({{ site.data.sections | jsonify }});
-  var colorScale2 = {};
+  var colorScale = {};
   sectionconfig.forEach(function(sec) {
-      colorScale2[sec.key] = {};
+      colorScale[sec.key] = {};
       sec.value.legends.forEach(function(leg) {
           var thresh = leg.type === "threshold"
             , sc = thresh ? d3.scaleThreshold() : d3.scaleOrdinal()
@@ -322,7 +322,7 @@
           ;
           if(thresh) sc.emptyValue = leg.fallback;
           sc.type = leg.type;
-          colorScale2[sec.key][leg.name] = sc.range(range).domain(domain);
+          colorScale[sec.key][leg.name] = sc.range(range).domain(domain);
       });
   });
 

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -210,7 +210,7 @@
         });
 
       signal.on("query", function(question) {
-        question.colorScale = colorScale[question.section][question.legend];
+        question.colorScale = colorScale2[question.section][question.legend];
         grid
             .query(question)
           ()
@@ -302,6 +302,28 @@
   ** The colors and labels for the various colorScales are all defined in
   ** Jekyll, so we're using Jekyll template statements to populate the object.
   */
+  var sectionconfig = d3.entries({{ site.data.sections | jsonify }});
+  var colorScale2 = {};
+  sectionconfig.forEach(function(sec) {
+      colorScale2[sec.key] = {};
+      sec.value.legends.forEach(function(leg) {
+          var thresh = leg.type === "threshold"
+            , sc = thresh ? d3.scaleThreshold() : d3.scaleOrdinal()
+            , range = leg.scale.map(function(s) { return s.color; })
+            , domain = leg.scale.map(function(s, i) {
+                  if(thresh) {
+                      s.max = s.max === "Infinity"
+                        ? 1 / 0
+                        : s.max
+                      ;
+                  }
+                  return thresh ? (s.max + 1) : s.label;
+                })
+          ;
+          colorScale2[sec.key][leg.name] = sc.range(range).domain(domain);
+      });
+  });
+
   var colorScale = {};
 {% for section in site.data.sections %}
   colorScale["{{ section[0] }}"] = {};
@@ -317,10 +339,10 @@
 
   // Store the type so we know when to prune the legend.
   colorScale["{{ section[0] }}"]["{{ legend.name }}"].type = "{{legend.type}}";
-
   {% endfor %}
 {% endfor %}
 
+console.log(colorScale, colorScale2)
 
   d3.selectAll(".tab-pane").each(function(d, i) {
       var name = this.id;

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -320,6 +320,8 @@
                   return thresh ? (s.max + 1) : s.label;
                 })
           ;
+          if(thresh) sc.emptyValue = leg.fallback;
+          sc.type = leg.type;
           colorScale2[sec.key][leg.name] = sc.range(range).domain(domain);
       });
   });

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -137,10 +137,9 @@
           .key(function(d) { return d.Year; })
           .key(function(d) { return d.State; })
           .rollup(function(leaves) { return Object.assign.apply(null, leaves); })
-          .map(dataset
-  {% comment %}Check Jekyll config to see if a year is being worked on{%endcomment %}
-  {% if site.filterYear %}
-          .filter(function(d) { return d.Year != +{{ site.filterYear }}; })
+          .map(dataset{% if site.filterYear %}
+  {% comment %}Check Jekyll config to see if a year is excluded.{% endcomment %}
+              .filter(function(d) { return d.Year != +{{ site.filterYear }}; })
   {% endif %})
       ;
   } // ingest()

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -225,7 +225,7 @@
 
         var visibleValues = "all";
         if(question.colorScale.type === "ordinal"){
-          visibleValues = d3.set(dataset.map(valueAccessor))
+          visibleValues = d3.set(grid.data().map(valueAccessor))
         }
 
         legend

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -326,26 +326,6 @@
       });
   });
 
-  var colorScale = {};
-{% for section in site.data.sections %}
-  colorScale["{{ section[0] }}"] = {};
-  {% for legend in section[1].legends %}{% capture colors %}{% for item in legend.scale %}{{ item.color }},{% endfor %}{% endcapture %}
-  colorScale["{{ section[0] }}"]["{{ legend.name }}"] = d3.scale{{ legend.type | capitalize }}()
-      .range(liquidToArray('{{ colors }}'))
-  {% if legend.type == "threshold" %}{% capture bins %}{% for item in legend.scale %}{% unless forloop.last %}{{ item.max }}{% endunless %},{% endfor %}{% endcapture %}
-      .domain(liquidToArray('{{ bins }}').map(function(d) { return +d + 1; }))
-  {% elsif legend.type == "ordinal" %} {% capture labels %}{% for item in legend.scale %}{{ item.label }},{% endfor %}{% endcapture %}
-      .domain(liquidToArray('{{ labels }}'))
-  {% endif %};
-  {% if legend.type == "threshold" %}colorScale["{{ section[0] }}"]["{{ legend.name }}"].emptyValue = {{ legend.fallback }};{% endif %}
-
-  // Store the type so we know when to prune the legend.
-  colorScale["{{ section[0] }}"]["{{ legend.name }}"].type = "{{legend.type}}";
-  {% endfor %}
-{% endfor %}
-
-console.log(colorScale, colorScale2)
-
   d3.selectAll(".tab-pane").each(function(d, i) {
       var name = this.id;
       d3.select(this).call(tabs[name]);

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -60,6 +60,7 @@ function Tabulus() {
         wiring.on("choice", function(arg) {
             arg.each(function(value, key) {
                 if(value.disable) {
+                  // e.g. Disable the "branch" if recipient is not Candidate
                     container.selectAll("select").each(function() {
                         var self = d3.select(this)
                           , name = self.attr("data-name")
@@ -79,7 +80,7 @@ function Tabulus() {
                         }
                       })
                     ;
-                }
+                } // if(value.disable)
                 // show the question if this is a question
                 if(value.question) {
                     container.select(".field-description")
@@ -94,7 +95,6 @@ function Tabulus() {
             update();
           })
         ;
-
     } // setup()
 
     // Set the state for the various controls, based on the query
@@ -128,6 +128,15 @@ function Tabulus() {
             if(!(curry.donor && curry.recipient)) return;
             if(curry.recipient.value === "Cand" && !curry.branch) return;
 
+            // Handle the Party/Party exception case here:
+            container.select("select[data-name='recipient']")
+              .select("option[value='Party']")
+                .node().disabled = (curry.donor.value == "StateP")
+            ;
+            container.select("select[data-name='donor']")
+              .select("option[value='StateP']")
+                .node().disabled = (curry.recipient.value === "Party")
+            ;
             curry._question = query.question = curry.donor.value
               + "To"
               + curry.recipient.value

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -156,6 +156,8 @@ function Tabulus() {
                 )
             ;
             query.legend = curry.donor.legend || "default";
+            if(curry.donor.value === "StateP" && curry.recipient.value === "Party")
+                query.legend = "Party2Party";
         } else {
             query.question = curry.question.value;
             query.label = curry.question.label;

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -18,11 +18,13 @@ function Tabulus() {
             .each(function() {
                 var self = d3.select(this)
                   , name = [query.section, self.attr("data-name")]
+                  , id = name.join('-')
+                  , uri = name.join('/')
                 ;
                 self
-                    .attr("id", name.join('-') + "-button")
-                    .attr("href", "../modals/" + name.join('/') + ".html")
-                    .attr("data-target", "#" + name.join('-') + "-modal")
+                    .attr("id", id + "-button")
+                    .attr("data-target", "#" + id + "-modal")
+                    .attr("href", "../modals/" + uri + ".html")
                 ;
               })
         ;


### PR DESCRIPTION
Adds colorschemes as per #185 

Legends now follow the general (layout) rule:

No/None/Prohibited
blue 1
blue 2
blue 3
blue 4
blue 5
N/A
N/A but
N/A if
Yes/Unlimited
Missing Data

The blahs are shades of blue, the N/As are shades of gray, the Yes/No are dark/light red and Missing Data is black and last.
I've tried to make sure this is globally followed here.

@curran this is ready for your review.