### PR TITLE
Fade out disabled options (Party to party)

### DIFF
--- a/_data/sections/contribution-limits/controls.yml
+++ b/_data/sections/contribution-limits/controls.yml
@@ -24,11 +24,11 @@
         - label: Candidate
           abbr: Cand
           disable: _branch
-        - label: State Party
-          abbr: Party
-          disable: branch
         - label: Political Action Committee (PAC)
           abbr: PAC
+          disable: branch
+        - label: State Party
+          abbr: Party
           disable: branch
     - id: branch
       label: Branch (Recipient)

--- a/_data/sections/contribution-limits/legends.yml
+++ b/_data/sections/contribution-limits/legends.yml
@@ -36,5 +36,8 @@
 - name: Party2Party
   type: singular
   scale:
-    - label: "Forbidden but funds get transferred between the two entities following internal procedures. And this is a sentence to act as a space filler."
+    - label: "This is more nuanced than donating.  Funds are able to be transferred
+      from state to local parties via internal processes.
+
+      And this is a sentence to act as a space filler."
       color: gray

--- a/css/style.css
+++ b/css/style.css
@@ -110,3 +110,6 @@ Part of https://github.com/cfinst/cfinst.github.io/issues/170
 .highlight-overlay .state {
     stroke-width: 1px;
 }
+option:disabled {
+    color: lightgrey;
+}

--- a/js/legend.js
+++ b/js/legend.js
@@ -48,6 +48,10 @@ function Legend() {
             return true;
           }
 
+          // For the singular scale, don't prune
+          if(data[query.section][query.legend].type === 'singular')
+            return d.label;
+
           // For ordinal scales, prune all values not present.
           return visibleValues.has(d.label)
         });

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -84,7 +84,7 @@
           ])
         , data = ingest(dataset)
       ;
-      
+
       // Reassign dataset here so it only includes years not filtered out.
       dataset = d3.merge(data.values().map(function(v) { return v.values(); }));
 
@@ -230,7 +230,6 @@
         ;
 
         var visibleValues = d3.set(dataset.map(valueAccessor));
-
         legend
             .query(question)
             .visibleValues(visibleValues)
@@ -321,15 +320,17 @@
                         ? 1 / 0
                         : s.max
                       ;
+                      return s.max + 1;
                   }
-                  return thresh ? (s.max + 1) : s.label;
+                  // Otherwise
+                  return s.label;
                 })
           ;
+
           if(thresh) sc.emptyValue = leg.fallback;
           colorScale[sec.key][leg.name] = sc.range(range).domain(domain);
       });
   });
-
   d3.selectAll(".tab-pane").each(function(d, i) {
       var name = this.id;
       d3.select(this).call(tabs[name]);


### PR DESCRIPTION
This fades out the Party dropdown options when they are disabled.  Additionally, the Party as recipient option is now the last one rather than in the middle.

Finally, there is a legend item placeholder to explain  Party to Party, presented **as an alternative to disabling options**.  This is only available via URL: https://cfinst.github.io/#contribution-limits?question=StatePToPartyLimit_Max&year=2014