### PR TITLE
Turn Party to Party into educational opportunity

### DIFF
--- a/_data/sections/contribution-limits/controls.yml
+++ b/_data/sections/contribution-limits/controls.yml
@@ -24,11 +24,11 @@
         - label: Candidate
           abbr: Cand
           disable: _branch
-        - label: Political Action Committee (PAC)
-          abbr: PAC
-          disable: branch
         - label: State Party
           abbr: Party
+          disable: branch
+        - label: Political Action Committee (PAC)
+          abbr: PAC
           disable: branch
     - id: branch
       label: Branch (Recipient)

--- a/js/tabulus.js
+++ b/js/tabulus.js
@@ -128,15 +128,6 @@ function Tabulus() {
             if(!(curry.donor && curry.recipient)) return;
             if(curry.recipient.value === "Cand" && !curry.branch) return;
 
-            // Handle the Party/Party exception case here:
-            container.select("select[data-name='recipient']")
-              .select("option[value='Party']")
-                .node().disabled = (curry.donor.value == "StateP")
-            ;
-            container.select("select[data-name='donor']")
-              .select("option[value='StateP']")
-                .node().disabled = (curry.recipient.value === "Party")
-            ;
             curry._question = query.question = curry.donor.value
               + "To"
               + curry.recipient.value


### PR DESCRIPTION
Undoing the special case handling of the dropdowns for PartyToParty.  The special case is now just the legend, which is of type "singular" (which doesn't exist as a scale type in d3, obviously), which is basically an unprunable "ordinal".

The legend can contain all the explanatory text for Pary to Party:
https://github.com/cfinst/cfinst.github.io/blob/master/_data/sections/contribution-limits/legends.yml#L39
