### PR TITLE
Fix Jekyll build

### DIFF
--- a/_data/sections/disclosure/legends.yml
+++ b/_data/sections/disclosure/legends.yml
@@ -64,7 +64,7 @@
   scale:
     - label: "Yes"
       color: red
-   - label: "No"
+    - label: "No"
       color: brown
     - label: "Disclosure Not Required"
       color: gray


### PR DESCRIPTION
Closes #245

This PR fixes an indentation issue that was causing the Jekyll build to fail (causing the site to stop updating).

We had never encountered this before, but now we know Jekyll/YML is quite particular about white space ;)