### PR TITLE
Unify color use for 'Disclosure Not Required'

### DIFF
--- a/_data/sections/disclosure/legends.yml
+++ b/_data/sections/disclosure/legends.yml
@@ -56,7 +56,7 @@
     - min: 100000001
       max: Infinity
       label: Disclosure Not Required
-      color: gray-light
+      color: gray
 # Mid-cycle values:
 # http://colorbrewer2.org/#type=sequential&scheme=Oranges&n=5
 - name: default


### PR DESCRIPTION
This PR makes "Disclosure Not Required" always map to the same color, across sections.