### PR TITLE
Scroll indicator hotfix

### DIFF
--- a/js/schematic.js
+++ b/js/schematic.js
@@ -342,12 +342,13 @@
       var windowBottom = scrollTop + windowHeight;
       var gridBottom = gridTop + gridHeight;
 
-      var showArrow = windowBottom <= gridBottom;
+      var epsilon = 2; // 2 pixels of wiggle room.
+      var showArrow = (windowBottom + epsilon) <= gridBottom;
 
       d3.select(".scroll-indicator")
           .transition()
           .style("opacity", showArrow ? 1 : 0);
   }
   window.onscroll = checkScroll;
-  checkScroll();
+  setInterval(checkScroll, 1000); // Handle things on the page rearranging (e.g. after data loads).
 }());


### PR DESCRIPTION
Addresses some issues seen in production but not when originally testing locally:

 * re-layout due to network latency - solution: check every second
 * mysterious sub-pixel offsets - solution: use an epsilon value of 2 pixels