### PR TITLE
Intro popup with cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ _data
 └── tabs.yml
 index.md
 _modals
+├── intro.md
 ├── contribution-limits
 │   ├── about.md
 │   └── howto.md
@@ -197,6 +198,7 @@ This file contains two parameters:
 
 ```
 _modals
+├── intro.md
 ├── contribution-limits
 │   ├── about.md
 │   └── howto.md
@@ -211,7 +213,12 @@ _modals
     └── howto.md
 ```
 
-The `_modals` directory contains configuration files that define what gets shown within the modal dialogs that pop up when you click on the "About this topic" and "Using this page" buttons.
+The `_modals` directory contains configuration files that define what gets shown within the modal dialogs that pop up when the page loads, and when you click on the "About this topic" and "Using this page" buttons.
+
+```
+_modals/intro.md
+```
+This file specifies the content of the introduction popup that appears the first time a user loads the page.
 
 ```
 _modals/:section/about.md

--- a/_includes/introModal.html
+++ b/_includes/introModal.html
@@ -1,0 +1,6 @@
+<div class="modal fade" id="intro-modal"
+    tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content"></div><!--.modal-content-->
+  </div><!--.modal-dialog-->
+</div><!--.modal-{{ button.name }}-->

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -4,4 +4,5 @@
 <script src="js/tabulus.js"></script>
 <script src="js/atlas.js"></script>
 <script src="js/legend.js"></script>
+<script src="js/introModal.js"></script>
 <script src="js/schematic.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -97,6 +97,8 @@
       <svg id="main"></svg>
     </section><!--.col-md-12-->
   </div><!--.row-->
+  {% include introModal.html %}
+
 </div>
 {% include javascripts.html %}
 

--- a/_modals/intro.md
+++ b/_modals/intro.md
@@ -1,0 +1,42 @@
+---
+layout: modal
+modal: introduction 
+title: Welcome to the CFI Campaign Finance Law Database!
+
+---
+
+Each of the graphic visualizations derived from the historical database of state
+campaign finance laws involves both a map and a grid. 
+
+#### _Grid_
+
+Each of the fifty states has a column in the grid. The horizontal rows represent
+years taken every two years, with the most recent completed year at the top. In
+the default setting, the grid uses the most recent year to line up the states in
+order of the answers to the question you are asking. The key to this sorting is
+shown to the right of the map. Looking up and down any one state's column will
+show if and when the state changed its law. Hovering the cursor over any box
+will give some of the details for each state and year.
+
+#### _Map_
+
+The map will show the most recent year by default. Hovering the cursor over a
+state will show details for the year being shown.
+
+#### _Sorting_
+
+Clicking on any year at the left of the grid will rearrange the grid according
+to the values in the year chosen. It will also change the map to show the laws
+for that year. There is also an option to sort the states alphabetically.
+
+#### _Downloading_
+
+You may download the answers to your specific question in a standard format that
+you can view in a spreadsheet or other program. You may also download all of the
+visualized information, or larger portions of the complete (and much larger)
+historical database.
+
+#### _Full Database_
+
+To see much more about contribution limits and the rest of this database (including the
+complete descriptive codebook) click on ___".

--- a/_modals/intro.md
+++ b/_modals/intro.md
@@ -1,14 +1,16 @@
 ---
 layout: modal
 modal: introduction 
-title: Welcome to the CFI Campaign Finance Law Database!
-
+title: Welcome to the Campaign Finance Law Database!
 ---
 
 Each of the graphic visualizations derived from the historical database of state
-campaign finance laws involves both a map and a grid. 
+campaign finance laws involves both a map and a grid.
 
-#### _Grid_
+ * Use the tabs at the top to navigate between topics.
+ * Use the controls on the right to navigate between fields.
+
+### Grid
 
 Each of the fifty states has a column in the grid. The horizontal rows represent
 years taken every two years, with the most recent completed year at the top. In
@@ -18,12 +20,12 @@ shown to the right of the map. Looking up and down any one state's column will
 show if and when the state changed its law. Hovering the cursor over any box
 will give some of the details for each state and year.
 
-#### _Map_
+### Map
 
 The map will show the most recent year by default. Hovering the cursor over a
 state will show details for the year being shown.
 
-#### _Sorting_
+### Sorting
 
 Clicking on any year at the left of the grid will rearrange the grid according
 to the values in the year chosen. It will also change the map to show the laws

--- a/_sass/_cfi-theme.scss
+++ b/_sass/_cfi-theme.scss
@@ -38,4 +38,5 @@ label, .chooser, .btn {
 /* Customize the appearance of the introduction modal. */
 #intro-modal .close {
     opacity: 1;
+    font-size: 40px;
 }

--- a/_sass/_cfi-theme.scss
+++ b/_sass/_cfi-theme.scss
@@ -34,3 +34,8 @@ label, .chooser, .btn {
     margin-bottom: -5px; /* This ensures no unnecessary space below all tabs. */
     margin-left: 8px; /* Add a bit of space between the text and logo. */
 }
+
+/* Customize the appearance of the introduction modal. */
+#intro-modal .close {
+    opacity: 1;
+}

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -4,8 +4,8 @@
 function triggerIntroModal(){
 
   // Determine whether or not the current user has seen
-  // this page before, using cookies.
-  // See Cookie documentation at https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+  // this page any time in the previous 24 hours, using cookies.
+  // Cookie documentation at https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
   var pageSeen = document.cookie.indexOf("pageSeen") !== -1;
 
   // Only show the intro modal if the current user
@@ -22,7 +22,10 @@ function triggerIntroModal(){
       remote: "/modals/intro.html"
     });
 
-    // Track that the current user has visited this page.
-    document.cookie = "pageSeen=true";
+    // The cookie will expire after one day.
+    var expiryDate = d3.timeDay.offset(new Date, 1);
+
+    // Track that the current user has visited this page using cookies.
+    document.cookie = "pageSeen=true;expires=" + expiryDate.toUTCString();
   }
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -1,3 +1,5 @@
 function triggerIntroModal(){
-  console.log("here");
+  $('#intro-modal').modal({
+    remote: '/modals/intro.html'
+  });
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -3,8 +3,10 @@
 // This function should be invoked once, on page load.
 function triggerIntroModal(){
 
-  // TODO get from cookie.
-  var pageSeen = false;
+  // Determine whether or not the current user has seen
+  // this page before, using cookies.
+  // See Cookie documentation at https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+  var pageSeen = document.cookie.indexOf("pageSeen") !== -1;
 
   // Only show the intro modal if the current user
   // is visiting the page for the first time.
@@ -20,7 +22,7 @@ function triggerIntroModal(){
       remote: "/modals/intro.html"
     });
 
-    // TODO set cookie here:
     // Track that the current user has visited this page.
+    document.cookie = "pageSeen=true";
   }
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -3,29 +3,29 @@
 // This function should be invoked once, on page load.
 function triggerIntroModal(){
 
-  // Determine whether or not the current user has seen
-  // this page any time in the previous 24 hours, using cookies.
-  // Cookie documentation at https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
-  var pageSeen = document.cookie.indexOf("pageSeen") !== -1;
+    // Determine whether or not the current user has seen
+    // this page any time in the previous 24 hours, using cookies.
+    // Cookie documentation at https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+    var pageSeen = document.cookie.indexOf("pageSeen") !== -1;
 
-  // Only show the intro modal if the current user
-  // is visiting the page for the first time.
-  if(!pageSeen){
+    // Only show the intro modal if the current user
+    // is visiting the page for the first time.
+    if(!pageSeen){
 
-    // Show the modal, via Bootstrap"s API.
-    // See http://getbootstrap.com/javascript/#via-javascript
-    $("#intro-modal").modal({
+        // Show the modal, via Bootstrap"s API.
+        // See http://getbootstrap.com/javascript/#via-javascript
+        $("#intro-modal").modal({
 
-      // This option tells Bootstrap to load the content from this file,
-      // which is compiled using Jekyll based on configurable content
-      // from _modals/intro.md.
-      remote: "/modals/intro.html"
-    });
+            // This option tells Bootstrap to load the content from this file,
+            // which is compiled using Jekyll based on configurable content
+            // from _modals/intro.md.
+            remote: "/modals/intro.html"
+        });
 
-    // The cookie will expire after one day.
-    var expiryDate = d3.timeDay.offset(new Date, 1);
+        // The cookie will expire after one day.
+        var expiryDate = d3.timeDay.offset(new Date, 1);
 
-    // Track that the current user has visited this page using cookies.
-    document.cookie = "pageSeen=true;expires=" + expiryDate.toUTCString();
-  }
+        // Track that the current user has visited this page using cookies.
+        document.cookie = "pageSeen=true;expires=" + expiryDate.toUTCString();
+    }
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -1,5 +1,20 @@
+// This triggers the introduction popup
+// that shows only the first time the page is loaded.
+// This function should be invoked once, on page load.
 function triggerIntroModal(){
-  $('#intro-modal').modal({
-    remote: '/modals/intro.html'
-  });
+
+  if(!localStorage.getItem("pageSeen")){
+
+    // Show the modal, via Bootstrap"s API.
+    // See http://getbootstrap.com/javascript/#via-javascript
+    $("#intro-modal").modal({
+
+      // This option tells Bootstrap to load the content from this file,
+      // which is compiled using Jekyll based on configurable content
+      // from _modals/intro.md.
+      remote: "/modals/intro.html"
+    });
+
+    localStorage.setItem("pageSeen", true);
+  }
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -3,6 +3,9 @@
 // This function should be invoked once, on page load.
 function triggerIntroModal(){
 
+  // Only show the intro modal if the current user
+  // is visiting the page for the first time.
+  // Using localStorage, documented at https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
   if(!localStorage.getItem("pageSeen")){
 
     // Show the modal, via Bootstrap"s API.
@@ -15,6 +18,7 @@ function triggerIntroModal(){
       remote: "/modals/intro.html"
     });
 
+    // Track that the current user has visited this page.
     localStorage.setItem("pageSeen", true);
   }
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -3,10 +3,12 @@
 // This function should be invoked once, on page load.
 function triggerIntroModal(){
 
+  // TODO get from cookie.
+  var pageSeen = false;
+
   // Only show the intro modal if the current user
   // is visiting the page for the first time.
-  // Using localStorage, documented at https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
-  if(!localStorage.getItem("pageSeen")){
+  if(!pageSeen){
 
     // Show the modal, via Bootstrap"s API.
     // See http://getbootstrap.com/javascript/#via-javascript
@@ -18,7 +20,7 @@ function triggerIntroModal(){
       remote: "/modals/intro.html"
     });
 
+    // TODO set cookie here:
     // Track that the current user has visited this page.
-    localStorage.setItem("pageSeen", true);
   }
 }

--- a/js/introModal.js
+++ b/js/introModal.js
@@ -1,0 +1,3 @@
+function triggerIntroModal(){
+  console.log("here");
+}

--- a/js/schematic.js
+++ b/js/schematic.js
@@ -29,6 +29,9 @@
     , backgroundRectFadeOpacity = {{ site.backgroundRectFadeOpacity }}
   ;
 
+  // Show the introductory modal dialog, if it's the first visit for this user.
+  triggerIntroModal();
+
   // Connect all the tabs
   {{ site.data.tabs | jsonify }}.forEach(function(tab) {
       tabs[tab.section] = Tabulus().connect(signal);


### PR DESCRIPTION
Due to unpredictable errors in FireFox with `localStorage` as noted in #274, this PR implements the intro popup with storage in Cookies.

The cookie expires after 24 hours, which if I remember correctly is what Michael suggested. So the intro popup will appear at most once daily for each user. Expiration was verified locally for a value of 10 seconds.