### PR TITLE
Tour Year Positions

### DIFF
--- a/_data/tour.yml
+++ b/_data/tour.yml
@@ -5,14 +5,15 @@
 - node: "#grid-view"
   orientation: top
   text: Each of the fifty states has a column in the grid.
-- node: "#grid-view"
+- node: "#year-left-2014"
   orientation: right
   text: The horizontal rows represent years taken every two years, with the most recent completed year at the top.
 - node: "#grid-view"
   orientation: center
   text: Looking up and down any one state’s column will show if and when the state changed its law. Hovering the cursor over any box will give some of the details for each state and year.
-- node: ".sorter-slicer"
-  text: Clicking on any year at the left of the grid will rearrange the grid according to the values in the year chosen. It will also change the map to show the laws for that year. There is also an option to sort the states alphabetically.
+- node: "#year-right-2006"
+  orientation: right
+  text: Clicking on any year at the left or right of the grid will rearrange the grid according to the values in the year chosen. It will also change the map to show the laws for that year. There is also an option to sort the states alphabetically.
 - node: "#contribution-limits"
   text: The contribution limits tab has a scheme where there is a donor, recipient, and (sometimes) branch of government. You can build a custom query using these dropdowns.
 - node: "#nav-other-restrictions"

--- a/js/grid.js
+++ b/js/grid.js
@@ -217,7 +217,6 @@ function Grid(){
       xAxisG
         .transition(t)
           .call(axisX.scale(xScale))
-        ;
       ;
       xAxisG.selectAll(".tick line")
           .attr("transform", "translate(" + (xScale.step() / 2) + ",0)")
@@ -237,7 +236,7 @@ function Grid(){
         .selectAll(".tick")
           .attr("id", function (year){
             return "year-right-" + year;
-          });
+          })
       ;
       svg.selectAll(".y.axis .tick line")
           .attr("transform", "translate(0," + (yScale.step() / 2) + ")")
@@ -248,7 +247,7 @@ function Grid(){
               query.year = +d;
               dispatch.call("query", null, query);
             }
-          );
+          )
       ;
   } // render_axes()
 

--- a/js/grid.js
+++ b/js/grid.js
@@ -225,11 +225,19 @@ function Grid(){
       yAxisG
         .transition(t)
           .call(axisY.scale(yScale))
+        .selectAll(".tick")
+          .attr("id", function (year){
+            return "year-left-" + year;
+          });
       ;
       yAxis2G
           .attr("transform", "translate(" + width + ",0)")
         .transition(t)
           .call(axisY2.scale(yScale))
+        .selectAll(".tick")
+          .attr("id", function (year){
+            return "year-right-" + year;
+          });
       ;
       svg.selectAll(".y.axis .tick line")
           .attr("transform", "translate(0," + (yScale.step() / 2) + ")")


### PR DESCRIPTION
Make tour stops point at specific years, with arrows.

![image](https://user-images.githubusercontent.com/68416/29721338-7565bb80-89da-11e7-91a7-4e873d26a96f.png)

![image](https://user-images.githubusercontent.com/68416/29721378-9ee31fe8-89da-11e7-9c69-00bd287f3673.png)

Unique IDs are added to each year tick mark on the left and right, so for example @bglavin you can change `node: "#year-left-2014"` to `node: "#year-left-2016"` when the new data is ready.